### PR TITLE
Unpublish GAP pages

### DIFF
--- a/data/bioscience-overview/gap-landcover-classification-raster/index.html
+++ b/data/bioscience-overview/gap-landcover-classification-raster/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 status: publish
-published: true
+published: false
 title: GAP Landcover Classification (Raster)
 author:
   display_name: Jessie Pechmann

--- a/data/gap-landcover-classification-vector/index.html
+++ b/data/gap-landcover-classification-vector/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 status: publish
-published: true
+published: false
 title: GAP Landcover Classification (Vector)
 author:
   display_name: Jessie Pechmann


### PR DESCRIPTION
Neither of the GAP data pages are complete or accurate, so they need to be unpublished. 

